### PR TITLE
build: configure secure release signing

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,8 +41,12 @@ jobs:
       - name: Install Android SDK packages
         run: sdkmanager "platforms;android-37.0" "build-tools;37.0.0"
 
-      - name: Run tests, lint and release build
-        run: ./gradlew testDebugUnitTest lintDebug assembleRelease --no-daemon
+      - name: Run tests and lint
+        run: ./gradlew testDebugUnitTest lintDebug --no-daemon
+
+      - name: Build release APK for pull request
+        if: github.event_name == 'pull_request'
+        run: ./gradlew assembleRelease --no-daemon
 
       - name: Upload verification reports
         if: always()
@@ -55,70 +59,61 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-      - name: Check signing configuration
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+      - name: Build and sign release APKs
+        if: github.event_name != 'pull_request'
         env:
-          KEYSTORE_BASE64: ${{ secrets.EASY_SHARE_KEYSTORE_BASE64 }}
-          KEYSTORE_PASSWORD: ${{ secrets.EASY_SHARE_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.EASY_SHARE_KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.EASY_SHARE_KEY_PASSWORD }}
+          SIGNING_KEYSTORE_BASE64: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
         run: |
           set -euo pipefail
-          test -n "$KEYSTORE_BASE64"
-          test -n "$KEYSTORE_PASSWORD"
-          test -n "$KEY_ALIAS"
-          test -n "$KEY_PASSWORD"
+          test -n "$SIGNING_KEYSTORE_BASE64"
+          test -n "$SIGNING_STORE_PASSWORD"
+          test -n "$SIGNING_KEY_PASSWORD"
+          test -n "$SIGNING_KEY_ALIAS"
 
-      - name: Sign release APKs
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
-        env:
-          KEYSTORE_BASE64: ${{ secrets.EASY_SHARE_KEYSTORE_BASE64 }}
-          KEYSTORE_PASSWORD: ${{ secrets.EASY_SHARE_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.EASY_SHARE_KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.EASY_SHARE_KEY_PASSWORD }}
-        run: |
-          set -euo pipefail
-          signing_dir="$(mktemp -d)"
+          signing_dir="$(mktemp -d "$RUNNER_TEMP/easy-share-signing.XXXXXX")"
           trap 'rm -rf "$signing_dir"' EXIT
-          keystore_path="$signing_dir/easy-share-release.jks"
-          unsigned_apk="app/build/outputs/apk/release/app-release-unsigned.apk"
+          keystore_path="$signing_dir/release.jks"
           build_tools="$ANDROID_HOME/build-tools/37.0.0"
 
-          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$keystore_path"
+          printf '%s' "$SIGNING_KEYSTORE_BASE64" | base64 --decode > "$keystore_path"
           chmod 600 "$keystore_path"
-          mkdir -p release
+          export SIGNING_KEYSTORE_PATH="$keystore_path"
 
-          cp "$unsigned_apk" "$signing_dir/universal-unsigned.apk"
-          cp "$unsigned_apk" "$signing_dir/arm64-unsigned.apk"
-          zip -q -d "$signing_dir/arm64-unsigned.apk" \
+          ./gradlew assembleRelease --no-daemon
+
+          signed_apk="app/build/outputs/apk/release/app-release.apk"
+          test -f "$signed_apk"
+
+          mkdir -p release
+          cp "$signed_apk" release/easy-share-universal.apk
+          cp "$signed_apk" "$signing_dir/arm64-unaligned.apk"
+          zip -q -d "$signing_dir/arm64-unaligned.apk" \
             'lib/armeabi/*' 'lib/armeabi-v7a/*' 'lib/x86/*' 'lib/x86_64/*'
 
           "$build_tools/zipalign" -f 4 \
-            "$signing_dir/universal-unsigned.apk" "$signing_dir/universal-aligned.apk"
-          "$build_tools/zipalign" -f 4 \
-            "$signing_dir/arm64-unsigned.apk" "$signing_dir/arm64-aligned.apk"
+            "$signing_dir/arm64-unaligned.apk" "$signing_dir/arm64-aligned.apk"
 
           "$build_tools/apksigner" sign \
             --ks "$keystore_path" \
-            --ks-key-alias "$KEY_ALIAS" \
-            --ks-pass env:KEYSTORE_PASSWORD \
-            --key-pass env:KEY_PASSWORD \
-            --out release/easy-share-universal.apk \
-            "$signing_dir/universal-aligned.apk"
-          "$build_tools/apksigner" sign \
-            --ks "$keystore_path" \
-            --ks-key-alias "$KEY_ALIAS" \
-            --ks-pass env:KEYSTORE_PASSWORD \
-            --key-pass env:KEY_PASSWORD \
+            --ks-key-alias "$SIGNING_KEY_ALIAS" \
+            --ks-pass env:SIGNING_STORE_PASSWORD \
+            --key-pass env:SIGNING_KEY_PASSWORD \
             --out release/easy-share-arm64.apk \
             "$signing_dir/arm64-aligned.apk"
+
+          rm -f "$keystore_path"
+          unset SIGNING_KEYSTORE_PATH SIGNING_KEYSTORE_BASE64
+          unset SIGNING_STORE_PASSWORD SIGNING_KEY_PASSWORD SIGNING_KEY_ALIAS
 
           "$build_tools/apksigner" verify --verbose release/easy-share-universal.apk
           "$build_tools/apksigner" verify --verbose release/easy-share-arm64.apk
           (cd release && sha256sum easy-share-*.apk > SHA256SUMS)
 
       - name: Upload signed APKs
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: easy-share-${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.jks
 *.keystore
 *.p12
+keystore.properties
 signing.properties
 
 # Generated Android packages and local verification artifacts.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Easy Share 是一款兼容互传联盟协议的 Android 本地文件互传应用
 ./gradlew testDebugUnitTest lintDebug assembleDebug
 ```
 
-Release 构建默认生成未签名 APK。正式包由 GitHub Actions 从仓库 Secrets 临时恢复 release keystore 后完成签名，私钥不会进入仓库或构建产物。
+Release 构建会优先使用环境变量或用户级 Gradle 属性提供的正式签名；凭据缺失时自动回退到 debug 签名，确保新 clone 的项目仍可直接编译。GitHub Actions 只在临时目录恢复 release keystore，并在签名后立即删除，私钥不会进入仓库或构建产物。
 
 ## 自动发布
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 
+import java.io.File
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -7,6 +8,22 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.parcelize)
 }
+
+fun signingValue(name: String): String? =
+    providers.environmentVariable(name)
+        .orElse(providers.gradleProperty(name))
+        .orNull
+
+val signingKeystorePath = signingValue("SIGNING_KEYSTORE_PATH")
+val signingStorePassword = signingValue("SIGNING_STORE_PASSWORD")
+val signingKeyAlias = signingValue("SIGNING_KEY_ALIAS")
+val signingKeyPassword = signingValue("SIGNING_KEY_PASSWORD")
+val hasReleaseSigningCredentials =
+    !signingKeystorePath.isNullOrBlank() &&
+        !signingStorePassword.isNullOrBlank() &&
+        !signingKeyAlias.isNullOrBlank() &&
+        !signingKeyPassword.isNullOrBlank() &&
+        File(signingKeystorePath).isFile
 
 android {
     namespace = "me.pipi.easyshare"
@@ -20,8 +37,24 @@ android {
         versionName = "0.1"
     }
 
+    signingConfigs {
+        create("release") {
+            if (hasReleaseSigningCredentials) {
+                storeFile = file(signingKeystorePath!!)
+                storePassword = signingStorePassword
+                keyAlias = signingKeyAlias
+                keyPassword = signingKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
+            signingConfig = if (hasReleaseSigningCredentials) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
             isMinifyEnabled = true
             isShrinkResources = true
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,14 +2,23 @@
 
 Easy Share 使用 GitHub Actions 构建并签名正式 APK。release keystore 不存放在仓库中，Workflow 只通过 GitHub Actions Secrets 在临时目录中恢复密钥，并在任务结束后删除。
 
-## 签名 Secrets
+## 签名配置
 
-仓库需要配置以下 Secrets：
+Gradle 的 Release 签名优先读取环境变量，其次读取用户目录下的 `~/.gradle/gradle.properties`。支持以下键：
 
-- `EASY_SHARE_KEYSTORE_BASE64`
-- `EASY_SHARE_KEYSTORE_PASSWORD`
-- `EASY_SHARE_KEY_ALIAS`
-- `EASY_SHARE_KEY_PASSWORD`
+- `SIGNING_KEYSTORE_PATH`
+- `SIGNING_STORE_PASSWORD`
+- `SIGNING_KEY_PASSWORD`
+- `SIGNING_KEY_ALIAS`
+
+四项均有效时使用正式 Release 签名；任意一项缺失或 keystore 不存在时自动回退到 debug 签名，因此新 clone 的项目无需私钥也能直接构建。正式构建不要使用 Gradle 的 `--info` 或 `--debug` 日志级别。
+
+本机构建应从系统钥匙串读取密码并通过环境变量注入，不在项目或用户属性文件中落盘。CI 使用以下 Repository Secrets：
+
+- `SIGNING_KEYSTORE_BASE64`
+- `SIGNING_STORE_PASSWORD`
+- `SIGNING_KEY_PASSWORD`
+- `SIGNING_KEY_ALIAS`
 
 本机 keystore 应离线备份。GitHub Secrets 无法作为可靠的密钥备份，也无法在保存后读取明文。丢失用于直接分发 APK 的签名私钥，将无法继续为现有安装提供无缝更新。
 
@@ -21,7 +30,7 @@ Easy Share 使用 GitHub Actions 构建并签名正式 APK。release keystore �
 - `easy-share-arm64.apk`
 - `SHA256SUMS`
 
-Pull Request 只执行验证，不读取签名 Secrets，也不生成正式签名包。
+Pull Request 使用 debug 回退签名执行完整 Release 构建，不读取签名 Secrets，也不生成正式签名 artifact。
 
 ## 创建 Release
 


### PR DESCRIPTION
## Summary
- configure release signing from environment variables with user Gradle properties as fallback
- preserve debug-signing fallback for credential-free clone builds
- migrate Actions to shared signing secret names and delete the temporary keystore immediately after signing
- document local Keychain injection and release hygiene

## Validation
- `./gradlew testDebugUnitTest lintDebug assembleRelease --no-daemon`
- formal local `assembleRelease` with Keychain-injected credentials
- `apksigner verify` confirms `CN=easy-share`, RSA 4096 and the expected SHA-256 certificate fingerprint
- `actionlint .github/workflows/android.yml`
- signing backup archive verified outside the repository