### PR TITLE
ci: publish releases automatically from main

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
   pull_request:
   workflow_dispatch:
 
@@ -13,8 +11,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: android-${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/v') && 'release' || github.ref }}
-  cancel-in-progress: true
+  group: android-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -128,39 +126,91 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Download signed APKs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: easy-share-${{ github.ref_name }}
+          name: easy-share-main
           path: release
 
-      - name: Create GitHub Release
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version_name="$(
+            sed -nE \
+              's/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+              app/build.gradle.kts
+          )"
+          test -n "$version_name"
+          test "$(printf '%s\n' "$version_name" | wc -l)" -eq 1
+          printf 'tag=v%s\n' "$version_name" >> "$GITHUB_OUTPUT"
+
+      - name: Create version tag and GitHub Release
+        id: publish
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        shell: bash
         run: |
-          gh release create "$GITHUB_REF_NAME" \
+          set -euo pipefail
+
+          if gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; skipping publication."
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          existing_tag="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
+              --jq '[.object.type, .object.sha] | @tsv' 2>/dev/null || true
+          )"
+
+          if [[ -n "$existing_tag" ]]; then
+            IFS=$'\t' read -r object_type object_sha <<< "$existing_tag"
+            if [[ "$object_type" != "commit" || "$object_sha" != "$GITHUB_SHA" ]]; then
+              echo "Tag $RELEASE_TAG already exists but does not point to this commit." >&2
+              exit 1
+            fi
+          else
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$RELEASE_TAG" \
+              -f sha="$GITHUB_SHA" >/dev/null
+          fi
+
+          gh release create "$RELEASE_TAG" \
             release/easy-share-universal.apk \
             release/easy-share-arm64.apk \
             release/SHA256SUMS \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --generate-notes \
-            --title "Easy Share $GITHUB_REF_NAME"
+            --title "Easy Share $RELEASE_TAG"
+
+          echo "published=true" >> "$GITHUB_OUTPUT"
 
       - name: Remove previous releases and release tags
+        if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          CURRENT_TAG: ${{ steps.version.outputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
-          current_tag="$GITHUB_REF_NAME"
           releases="$(
             gh api \
               --paginate \
@@ -169,7 +219,7 @@ jobs:
           )"
 
           while IFS=$'\t' read -r release_id release_tag; do
-            if [[ -n "$release_id" && "$release_tag" != "$current_tag" ]]; then
+            if [[ -n "$release_id" && "$release_tag" != "$CURRENT_TAG" ]]; then
               echo "Removing previous release: $release_tag"
               gh api \
                 --method DELETE \
@@ -186,7 +236,7 @@ jobs:
 
           while IFS= read -r tag_ref; do
             tag_name="${tag_ref#refs/tags/}"
-            if [[ -n "$tag_name" && "$tag_name" != "$current_tag" ]]; then
+            if [[ -n "$tag_name" && "$tag_name" != "$CURRENT_TAG" ]]; then
               echo "Removing previous release tag: $tag_name"
               gh api \
                 --method DELETE \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -32,20 +32,17 @@ Gradle 的 Release 签名优先读取环境变量，其次读取用户目录下�
 
 Pull Request 使用 debug 回退签名执行完整 Release 构建，不读取签名 Secrets，也不生成正式签名 artifact。
 
-## 创建 Release
+## 自动创建 Release
 
 1. 更新 `app/build.gradle.kts` 中的 `versionCode` 与 `versionName`。
-2. 确认默认分支的 CI 通过。
-3. 创建并推送与版本一致的标签，例如：
+2. 确认 Pull Request 的 CI 通过。
+3. 将版本变更合并到 `main`。
 
-```bash
-git tag v0.2
-git push origin v0.2
-```
-
-标签 Workflow 会验证、签名并创建对应的 GitHub Release。
+`main` 的 Workflow 会读取 `versionName`，自动创建对应的 `v<versionName>` 标签，使用正式签名构建 APK，并发布 GitHub Release。同一版本的 Release 已存在时会安全跳过，不会重复发布。手动运行 Workflow 只构建并上传 artifact，不会创建 Release。
 
 新 Release 创建成功后，Workflow 会自动删除此前的 GitHub Releases 及其 `v*` 发布标签，仓库只保留最新 Release 和当前版本标签。清理步骤不会在新 Release 创建失败时执行，也不会删除非 `v*` 标签。
+
+`main` 的发布任务按顺序执行，避免连续合并时后一次运行中断前一次发布或清理过程。
 
 ## 签名迁移提醒
 


### PR DESCRIPTION
## 说明

当前 Release 仍停留在 v0.1，是因为原 workflow 只在手动推送 `v*` 标签后发布；合并 0.2 代码本身不会触发发布。

## 改动

- 合并到 `main` 后，从 Gradle 的 `versionName` 自动解析发布标签
- 自动创建对应标签并发布正式签名的 universal / arm64 APK 与校验文件
- 同版本 Release 已存在时安全跳过，避免重复发布
- 仅在新版本发布成功后清理旧 Release 与旧 `v*` 标签
- 串行执行 `main` 发布任务，避免连续合并导致发布流程互相取消
- 更新发布文档，不再要求手动创建标签

本 PR 合并后会触发 `main` workflow，自动创建 v0.2 Release，并在成功后删除 v0.1 Release 与标签。

## 校验

- `actionlint .github/workflows/android.yml`
- `git diff --check`
- 本地版本解析结果：`v0.2`
- 已确认远端 v0.2 Release 与标签均不存在
