### PR TITLE
release: prepare 0.4 secure receive mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,8 +33,8 @@ android {
         applicationId = "me.pipi.easyshare"
         minSdk = 31
         targetSdk = 37
-        versionCode = 3
-        versionName = "0.3"
+        versionCode = 4
+        versionName = "0.4"
     }
 
     signingConfigs {

--- a/app/src/main/java/me/pipi/easyshare/AppSettings.kt
+++ b/app/src/main/java/me/pipi/easyshare/AppSettings.kt
@@ -26,6 +26,12 @@ class AppSettings(private val context: Context) {
             prefs.edit { putBoolean("enhancedModeEnabled", value) }
         }
 
+    var secureReceiveOnly: Boolean
+        get() = prefs.getBoolean("secureReceiveOnly", false)
+        set(value) {
+            prefs.edit { putBoolean("secureReceiveOnly", value) }
+        }
+
     var brandId: Int
         get() = prefs.getInt("brandId", -1)
         set(value) {

--- a/app/src/main/java/me/pipi/easyshare/MainActivity.kt
+++ b/app/src/main/java/me/pipi/easyshare/MainActivity.kt
@@ -76,6 +76,7 @@ class MainActivity : ComponentActivity() {
                     onDeviceNameChanged = viewModel::setDeviceName,
                     onBrandChanged = viewModel::setBrand,
                     onChooseReceivePath = { chooseReceivePath.launch(null) },
+                    onSecureReceiveOnlyChanged = viewModel::setSecureReceiveOnly,
                     onEnhancedModeChanged = viewModel::setEnhancedMode,
                     onCaptureLogs = ::captureAndShareLogs,
                 )

--- a/app/src/main/java/me/pipi/easyshare/SessionSecurity.kt
+++ b/app/src/main/java/me/pipi/easyshare/SessionSecurity.kt
@@ -9,6 +9,12 @@ import java.util.Base64
 import javax.net.ssl.X509TrustManager
 
 object SessionSecurity {
+    fun usesModernProtocol(cryptoVersion: Int?): Boolean =
+        cryptoVersion != null && cryptoVersion >= BleSecurity.MODERN_CRYPTO_VERSION
+
+    fun isPeerAllowed(secureReceiveOnly: Boolean, cryptoVersion: Int?): Boolean =
+        !secureReceiveOnly || usesModernProtocol(cryptoVersion)
+
     fun generateToken(): String = Base64.getUrlEncoder().withoutPadding().encodeToString(
         ByteArray(32).also(SecureRandom()::nextBytes),
     )

--- a/app/src/main/java/me/pipi/easyshare/services/GattServerService.kt
+++ b/app/src/main/java/me/pipi/easyshare/services/GattServerService.kt
@@ -37,6 +37,7 @@ import me.pipi.easyshare.AppSettings
 import me.pipi.easyshare.BleSecurity
 import me.pipi.easyshare.BuildConfig
 import me.pipi.easyshare.R
+import me.pipi.easyshare.SessionSecurity
 import me.pipi.easyshare.models.DeviceInfo
 import me.pipi.easyshare.models.P2pInfo
 import me.pipi.easyshare.utils.BleUtils
@@ -309,6 +310,14 @@ class GattServerService : Service() {
                 var p2pInfo: P2pInfo = JsonWithUnknownKeys.decodeFromString(
                     data.decodeToString(throwOnInvalidSequence = true),
                 )
+                if (!SessionSecurity.isPeerAllowed(
+                        AppSettings(this@GattServerService).secureReceiveOnly,
+                        p2pInfo.cryptoVersion,
+                    )
+                ) {
+                    Log.i(TAG, "Rejected peer without secure protocol support")
+                    return false
+                }
                 val ecKey = p2pInfo.key
                 if (ecKey != null) {
                     val cipher = BleSecurity.deriveSessionKey(ecKey, p2pInfo.cryptoVersion)
@@ -329,9 +338,7 @@ class GattServerService : Service() {
                 require(p2pInfo.psk.toByteArray().size in MIN_PSK_BYTES..MAX_PSK_BYTES)
                 require(p2pInfo.mac.toByteArray().size <= MAX_MAC_BYTES)
                 require(p2pInfo.port in 1..65535)
-                if (p2pInfo.cryptoVersion != null &&
-                    p2pInfo.cryptoVersion >= BleSecurity.MODERN_CRYPTO_VERSION
-                ) {
+                if (SessionSecurity.usesModernProtocol(p2pInfo.cryptoVersion)) {
                     require(p2pInfo.authToken?.length in 32..128)
                     require(p2pInfo.certificateSha256?.matches(Regex("[0-9a-f]{64}")) == true)
                 }

--- a/app/src/main/java/me/pipi/easyshare/services/P2pReceiverService.kt
+++ b/app/src/main/java/me/pipi/easyshare/services/P2pReceiverService.kt
@@ -59,7 +59,6 @@ import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
 import me.pipi.easyshare.AppSettings
-import me.pipi.easyshare.BleSecurity
 import me.pipi.easyshare.BuildConfig
 import me.pipi.easyshare.IncomingTransferActivity
 import me.pipi.easyshare.MyApplication
@@ -334,6 +333,16 @@ class P2pReceiverService : BaseP2pService() {
             stopSelf(startId)
             return START_NOT_STICKY
         }
+        if (!SessionSecurity.isPeerAllowed(
+                AppSettings(this).secureReceiveOnly,
+                info.cryptoVersion,
+            )
+        ) {
+            Log.i(TAG, "Rejected peer without secure protocol support")
+            MyApplication.getInstance().clearBusy()
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
 
         val localTaskId = Random.nextInt()
         retainTransferNotification = false
@@ -510,8 +519,7 @@ class P2pReceiverService : BaseP2pService() {
         localTaskId: Int,
     ) = coroutineScope {
         updateStage(localTaskId, getString(R.string.device), LiveStage.PREPARING)
-        val secureSession = p2pInfo.cryptoVersion != null &&
-            p2pInfo.cryptoVersion >= BleSecurity.MODERN_CRYPTO_VERSION
+        val secureSession = SessionSecurity.usesModernProtocol(p2pInfo.cryptoVersion)
         if (secureSession) {
             require(!p2pInfo.authToken.isNullOrBlank())
             require(p2pInfo.certificateSha256?.matches(Regex("[0-9a-f]{64}")) == true)

--- a/app/src/main/java/me/pipi/easyshare/ui/main/MainScreen.kt
+++ b/app/src/main/java/me/pipi/easyshare/ui/main/MainScreen.kt
@@ -58,6 +58,7 @@ fun MainScreen(
     onDeviceNameChanged: (String) -> Unit,
     onBrandChanged: (Int) -> Unit,
     onChooseReceivePath: () -> Unit,
+    onSecureReceiveOnlyChanged: (Boolean) -> Unit,
     onEnhancedModeChanged: (Boolean) -> Unit,
     onCaptureLogs: () -> Unit,
 ) {
@@ -132,6 +133,18 @@ fun MainScreen(
                                 checked = state.receiverEnabled,
                                 enabled = !state.busy,
                                 onCheckedChange = onReceiverChanged,
+                            )
+                        },
+                    )
+                    SettingDivider()
+                    NativeSettingItem(
+                        title = stringResource(R.string.secure_receive_title),
+                        summary = stringResource(R.string.secure_receive_summary),
+                        onClick = { onSecureReceiveOnlyChanged(!state.secureReceiveOnly) },
+                        trailing = {
+                            Switch(
+                                checked = state.secureReceiveOnly,
+                                onCheckedChange = onSecureReceiveOnlyChanged,
                             )
                         },
                     )

--- a/app/src/main/java/me/pipi/easyshare/ui/main/MainViewModel.kt
+++ b/app/src/main/java/me/pipi/easyshare/ui/main/MainViewModel.kt
@@ -32,6 +32,7 @@ data class MainUiState(
     val configuredBrandId: Int = -1,
     val effectiveBrandId: Int = 0,
     val receivePath: String? = null,
+    val secureReceiveOnly: Boolean = false,
     val shizukuAvailable: Boolean = false,
     val shizukuGranted: Boolean = false,
 )
@@ -48,6 +49,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             configuredBrandId = settings.brandId,
             effectiveBrandId = DeviceUtils.getLocalBrandId(),
             receivePath = settings.downloadUri,
+            secureReceiveOnly = settings.secureReceiveOnly,
         )
     )
     val state: StateFlow<MainUiState> = _state.asStateFlow()
@@ -133,6 +135,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun setReceivePath(uri: Uri) {
         settings.downloadUri = uri.toString()
         _state.value = _state.value.copy(receivePath = uri.toString())
+    }
+
+    fun setSecureReceiveOnly(enabled: Boolean) {
+        settings.secureReceiveOnly = enabled
+        _state.value = _state.value.copy(secureReceiveOnly = enabled)
     }
 
     fun setEnhancedMode(enabled: Boolean) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -5,10 +5,12 @@
     <string name="discoverable_desc">已准备好接收附近设备发送的文件</string>
     <string name="receiver_switch_title">接收文件</string>
     <string name="receiver_tile_label">互传联盟</string>
-    <string name="receiver_switch_summary">需先开启 Wi-Fi 和蓝牙</string>
+    <string name="receiver_switch_summary">接收前需开启 Wi-Fi 和蓝牙</string>
+    <string name="secure_receive_title">安全互传</string>
+    <string name="secure_receive_summary">仅接收支持安全协议的设备</string>
     <string name="compatibility_summary">支持互传联盟，可与附近兼容设备快速互传文件</string>
     <string name="shizuku_authorization">增强模式</string>
-    <string name="shizuku_desc">通过 Shizuku 获取本机 MAC 地址</string>
+    <string name="shizuku_desc">使用 Shizuku 获取本机 MAC</string>
     <string name="shizuku_unavailable">请先启动 Shizuku</string>
 
     <string name="noti_connecting">正在建立连接…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,10 +4,12 @@
     <string name="discoverable_desc">Ready to receive files from nearby devices</string>
     <string name="receiver_switch_title">Receive files</string>
     <string name="receiver_tile_label">Easy Share Alliance</string>
-    <string name="receiver_switch_summary">Requires Wi-Fi and Bluetooth</string>
+    <string name="receiver_switch_summary">Wi-Fi and Bluetooth must be on</string>
+    <string name="secure_receive_title">Secure transfer</string>
+    <string name="secure_receive_summary">Only receive from devices that support the secure protocol</string>
     <string name="compatibility_summary">Easy Share Alliance support for fast transfers with compatible nearby devices</string>
     <string name="shizuku_authorization">Enhanced mode</string>
-    <string name="shizuku_desc">Use Shizuku to read this device’s MAC address</string>
+    <string name="shizuku_desc">Get this device’s MAC with Shizuku</string>
     <string name="shizuku_unavailable">Start Shizuku first</string>
 
     <string name="noti_connecting">Establishing connection…</string>

--- a/app/src/test/java/me/pipi/easyshare/SessionSecurityTest.kt
+++ b/app/src/test/java/me/pipi/easyshare/SessionSecurityTest.kt
@@ -11,6 +11,24 @@ import org.junit.Test
 
 class SessionSecurityTest {
     @Test
+    fun secureReceivePolicyRejectsLegacyPeersOnlyWhenEnabled() {
+        assertTrue(SessionSecurity.isPeerAllowed(false, null))
+        assertTrue(SessionSecurity.isPeerAllowed(false, 1))
+        assertTrue(
+            SessionSecurity.isPeerAllowed(false, BleSecurity.MODERN_CRYPTO_VERSION),
+        )
+
+        assertFalse(SessionSecurity.isPeerAllowed(true, null))
+        assertFalse(SessionSecurity.isPeerAllowed(true, 1))
+        assertTrue(
+            SessionSecurity.isPeerAllowed(true, BleSecurity.MODERN_CRYPTO_VERSION),
+        )
+        assertTrue(
+            SessionSecurity.isPeerAllowed(true, BleSecurity.MODERN_CRYPTO_VERSION + 1),
+        )
+    }
+
+    @Test
     fun tokensAreUniqueAndUrlSafe() {
         val first = SessionSecurity.generateToken()
         val second = SessionSecurity.generateToken()


### PR DESCRIPTION
## What changed

- add a **Secure transfer** toggle directly below **Receive files**
- persist the opt-in setting, defaulting to off for existing compatibility
- reject peers without modern protocol support at both the BLE metadata boundary and the receiver service entry point
- centralize modern-protocol checks and cover the receive policy with unit tests
- polish the related English and Simplified Chinese setting summaries
- bump the app to versionCode 4 / versionName 0.4

## Why

Easy Share previously accepted a missing or legacy `cryptoVersion` for alliance compatibility, which allowed sessions to fall back to the legacy security path. Users now have an explicit way to require the modern authenticated protocol when receiving.

## User impact

When **Secure transfer** is enabled, the device only accepts incoming transfers from peers using the modern secure protocol. The setting remains off by default, so existing alliance compatibility is unchanged until the user opts in. Sending behavior is unaffected.

## Root cause

The receiver treated protocol downgrade as an unconditional compatibility behavior and had no user-configurable policy at the GATT or P2P service boundaries.

## Validation

- `./gradlew --no-daemon testDebugUnitTest lintDebug assembleRelease --console=plain`
- officially signed Release APK built successfully
- Pixel 9 Pro verified the setting placement, single-line copy, toggle behavior, and persistence across app restart
- `git diff --check`
